### PR TITLE
Fix: Fixing CD deploy working-directory issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
     needs: ci
     if: github.ref == 'refs/heads/l6_dev_ops_main'
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
     steps:
       - name: Trigger Render deploy
         run: curl -X POST "${{ secrets.RENDER_DEPLOY_HOOK }}"


### PR DESCRIPTION
- Deploy stage of the CD workflow following CI would attempt to open the "enhanced_access_portal" directory which would not exist as on this stage with a new linux VM no repository is actually checked out during this time