### PR TITLE
Ammendment: Smoke test silencing for logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,5 @@ jobs:
 
       - name: Post-deploy smoke test
         run: |
-          curl --fail --show-error --max-time 60 \
+          curl --fail --silent --show-error --max-time 60 --output /dev/null \
             https://enhanced-access-portal-v2-l6-devops.onrender.com/login_page/


### PR DESCRIPTION
- Made an ammendment where the wall of HTML created on a smoke test is removed to maek logging easier to understand and screenshot.

- As well as suppressing the progress meter to leave the final step green or red with no noise.